### PR TITLE
Update all calls using entrezgene to entrezgene_id

### DIFF
--- a/inst/app/src/built_in_files/hs_dbd_tf.csv
+++ b/inst/app/src/built_in_files/hs_dbd_tf.csv
@@ -1,4 +1,4 @@
-ensembl_peptide_id,tf_gene,entrezgene
+ensembl_peptide_id,tf_gene,entrezgene_id
 ENSP00000000442,ESRRA,2101
 ENSP00000005082,ZNF195,7748
 ENSP00000006015,HOXA11,3207

--- a/inst/app/src/built_in_files/mm_dbd_tf.csv
+++ b/inst/app/src/built_in_files/mm_dbd_tf.csv
@@ -1,4 +1,4 @@
-ensembl_peptide_id,tf_gene,entrezgene
+ensembl_peptide_id,tf_gene,entrezgene_id
 ENSMUSP00000000010,Hoxb9,15417
 ENSMUSP00000000080,Klf6,23849
 ENSMUSP00000000095,Tbx2,21385

--- a/inst/app/src/built_in_files/support_attris.csv
+++ b/inst/app/src/built_in_files/support_attris.csv
@@ -18,4 +18,4 @@
 "refseq_peptide","RefSeq peptide ID (refseq_peptide)"
 "pdb","PDB ID (pdb)"
 "protein_id","INSDC protein ID (protein_id)"
-"entrezgene","NCBI gene ID (entrezgene)"
+"entrezgene_id","NCBI gene ID (entrezgene_id)"

--- a/inst/app/src/built_in_files/support_filters.csv
+++ b/inst/app/src/built_in_files/support_filters.csv
@@ -18,4 +18,4 @@
 "refseq_peptide","RefSeq peptide ID(s) [e.g. NP_000005]"
 "pdb","PDB ID(s) [e.g. 10GS]"
 "protein_id","INSDC protein ID(s) [e.g. AAA02487]"
-"entrezgene","NCBI gene ID(s) [e.g. 1]"
+"entrezgene_id","NCBI gene ID(s) [e.g. 1]"

--- a/inst/app/src/server_code/analysis/gsea.R
+++ b/inst/app/src/server_code/analysis/gsea.R
@@ -187,17 +187,17 @@ observeEvent(input$run_gsea, {
             bmart_db = biomaRt::useMart("ensembl",dataset=input$gsea_species)
             flist <- unique(biomaRt::getBM(
                 filters = "external_gene_name",
-                attributes="entrezgene",
+                attributes="entrezgene_id",
                 values= flist,
                 mart= bmart_db))
-            flist <- flist$entrezgene
+            flist <- flist$entrezgene_id
             if(!is.null(bglist) && length(bglist)) {
                 bglist <- unique(biomaRt::getBM(
                     filters = "external_gene_name",
-                    attributes="entrezgene",
+                    attributes="entrezgene_id",
                     values= bglist,
                     mart= bmart_db))
-                bglist <- bglist$entrezgene
+                bglist <- bglist$entrezgene_id
             } else {
                 bglist <- NULL
             }

--- a/inst/app/src/server_code/toolkit/biomart.R
+++ b/inst/app/src/server_code/toolkit/biomart.R
@@ -39,7 +39,7 @@ output$biomart_ui <- renderUI({
                          tags$p("Assume you have a list of HGNC gene symbol, and want to find corresponding entrez gene ids, then do the following:"),
                          tags$li("Select filter, hgnc_symbol in the filters table."),
                          tags$li("Upload HGNC gene symbol lists by clicking the hgnc_symbol button."),
-                         tags$li("Choose hgnc_symbol, entrezgene in the attribute table, and press the query button."),
+                         tags$li("Choose hgnc_symbol, entrezgene_id in the attribute table, and press the query button."),
                          tags$li("See https://bioconductor.org/packages/release/bioc/vignettes/biomaRt/inst/doc/biomaRt.html for more examples."),
                          tags$hr(),
                          fluidRow(


### PR DESCRIPTION
Fixes #17. The attribute has been renamed in recent versions of biomaRt.